### PR TITLE
add initial LoRA support

### DIFF
--- a/configs/ddpo_sd_imagenet_lora.yml
+++ b/configs/ddpo_sd_imagenet_lora.yml
@@ -1,0 +1,40 @@
+method:
+  name : "DDPO"
+
+model:
+  model_path: "stabilityai/stable-diffusion-2-1-base"
+  model_arch_type: "LDMUnet"
+  attention_slicing: True
+  xformers_memory_efficient: True
+  gradient_checkpointing: True
+  lora_rank: 4
+sampler:
+  num_inference_steps: 50
+
+optimizer:
+  name: "adamw"
+  kwargs:
+    lr: 1.0e-4
+    weight_decay: 1.0e-4
+    betas: [0.9, 0.999]
+
+scheduler:
+  name: "linear" # Name of learning rate scheduler
+  kwargs:
+    start_factor: 1.0
+    end_factor: 1.0
+  
+logging:
+  run_name: 'ddpo_sd_imagenet_lora'
+  wandb_project: 'DRLX'
+
+train:
+  num_epochs: 200
+  num_samples_per_epoch: 256
+  batch_size: 4
+  sample_batch_size: 32
+  grad_clip: 1.0
+  checkpoint_interval: 10
+  tf32: True
+  suppress_log_keywords: "diffusers.pipelines,transformers"
+  save_samples: False

--- a/examples/ddpo_imagenet_lora_inference.py
+++ b/examples/ddpo_imagenet_lora_inference.py
@@ -1,0 +1,12 @@
+# Inference:
+
+from diffusers import StableDiffusionPipeline
+import torch
+
+pipe = StableDiffusionPipeline.from_pretrained("stabilityai/stable-diffusion-2-1-base", torch_dtype=torch.float16).to('cuda')
+pipe.load_lora_weights("output/ddpo_sd_imagenet_lora")
+pipe.enable_attention_slicing()
+
+prompt = "llama"
+image = pipe(prompt).images[0]
+image.save("test.jpeg")

--- a/examples/train_ddpo_imagenet_lora.py
+++ b/examples/train_ddpo_imagenet_lora.py
@@ -1,0 +1,19 @@
+import torch
+from drlx.trainer.ddpo_trainer import DDPOTrainer
+from drlx.configs import DRLXConfig
+from drlx.reward_modelling.aesthetics import Aesthetics
+from drlx.pipeline.imagenet_animal_prompts import ImagenetAnimalPrompts
+from drlx.utils import get_latest_checkpoint
+
+config = DRLXConfig.load_yaml("configs/ddpo_sd_imagenet_lora.yml")
+
+pipe = ImagenetAnimalPrompts(prefix='', postfix='', num=config.train.num_samples_per_epoch)
+resume = False
+
+trainer = DDPOTrainer(config)
+
+if resume:
+    cp_dir = get_latest_checkpoint(f"checkpoints/{config.logging.run_name}")
+    trainer.load_checkpoint(cp_dir)
+
+trainer.train(pipe, Aesthetics())

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ torchvision
 torchtyping
 einops
 diffusers
+peft
 transformers
 accelerate
 datasets

--- a/src/drlx/configs.py
+++ b/src/drlx/configs.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, field, asdict
 from typing import Any, Dict, List, Optional, Set
 import yaml
 
-
 @dataclass
 class ConfigClass:
     @classmethod
@@ -238,16 +237,8 @@ class ModelConfig(ConfigClass):
     :param gradient_checkpointing: Whether to use gradient checkpointing
     :type gradient_checkpointing: bool
 
-    :param peft_config: configuration for peft (Parameter Efficient Fine-Tuning library).
-        Peft is designed to reduce the number of parameters to train and the memory footprint,
-        without significant performance loss. It supports multiple techniques such as LORA
-        or prefix tuning (cf. https://github.com/huggingface/peft).
-
-        Here is an example of LORA configuration:
-            {"peft_type": "LORA", "r": 8, "lora_alpha": 32, "lora_dropout": 0.1}
-
-        (parameter-efficient fine-tuning was previously done in trlx with OpenDelta, but it is no longer supported)
-    :type peft_config: Union[peft.PeftConfig, Dict[str, Any]]
+    :param lora_rank: Rank of LoRA matrix
+    :type lora_rank: int
     """
 
     model_path: str = None
@@ -257,7 +248,7 @@ class ModelConfig(ConfigClass):
     attention_slicing: bool = False
     xformers_memory_efficient: bool = False 
     gradient_checkpointing: bool = False
-    peft_config: Dict[str, Any] = field(default_factory=dict) # TODO: add PEFT support
+    lora_rank: int = None
 
 
 

--- a/src/drlx/pipeline/imagenet_animal_prompts.py
+++ b/src/drlx/pipeline/imagenet_animal_prompts.py
@@ -9,8 +9,9 @@ class ImagenetAnimalPrompts(PromptPipeline):
     """
     def __init__(self, prefix='A picture of a ', postfix=', 4k unreal engine', num=10000, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        r = requests.get("https://raw.githubusercontent.com/formigone/tf-imagenet/master/LOC_synset_mapping.txt")
-        with open("LOC_synset_mapping.txt", "wb") as f: f.write(r.content)
+        if not Path('LOC_synset_mapping.txt').exists():
+            r = requests.get("https://raw.githubusercontent.com/formigone/tf-imagenet/master/LOC_synset_mapping.txt")
+            with open("LOC_synset_mapping.txt", "wb") as f: f.write(r.content)
         self.synsets = {k:v for k,v in [o.split(',')[0].split(' ', maxsplit=1) for o in Path('LOC_synset_mapping.txt').read_text().splitlines()]}
         self.imagenet_classes = list(self.synsets.values())
         self.prefix = prefix

--- a/src/drlx/trainer/__init__.py
+++ b/src/drlx/trainer/__init__.py
@@ -36,7 +36,7 @@ class BaseTrainer:
         """
         optimizer_class = get_optimizer_class(self.config.optimizer.name)
         optimizer = optimizer_class(
-            self.model.parameters(),
+            filter(lambda p: p.requires_grad, self.model.parameters()),
             **self.config.optimizer.kwargs,
         )
         return optimizer


### PR DESCRIPTION
Adding initial LoRA support, example training and inference script. It only supports LoRA and only the LoRA rank arg can be provided, similar to the examples in Diffusers. We may try to generalize this further later on.